### PR TITLE
IMP duplicate output file instead of overwriting it

### DIFF
--- a/replace_attrs.py
+++ b/replace_attrs.py
@@ -212,7 +212,8 @@ for xml_file in all_xml_files:
             else:
                 confirm = 'y'
             if confirm.lower()[0] == 'y':
-                with open(xml_file, 'wb') as rf:
+                new_file_name = f"{xml_file.rsplit('.', 1)[0]}_v17migrated.{xml_file.rsplit('.', 1)[1]}"
+                with open(new_file_name, 'wb') as rf:
                     html = soup.prettify(formatter=xml_4indent_formatter)
                     html = prettify_output(html)
                     for percent_d_result in percent_d_results.keys():

--- a/replace_attrs.py
+++ b/replace_attrs.py
@@ -212,7 +212,7 @@ for xml_file in all_xml_files:
             else:
                 confirm = 'y'
             if confirm.lower()[0] == 'y':
-                new_file_name = f"{xml_file.rsplit('.', 1)[0]}_v17migrated.{xml_file.rsplit('.', 1)[1]}"
+                new_file_name = "_migrated.".join(xml_file.rsplit(".", 1))
                 with open(new_file_name, 'wb') as rf:
                     html = soup.prettify(formatter=xml_4indent_formatter)
                     html = prettify_output(html)


### PR DESCRIPTION
Small modification to instead of overwriting original files, it creates a copy so we can use compare tools to integrate changes with our code in a similar way like bt_translate translation files work.